### PR TITLE
Add Arrayable interface implementation to Layout

### DIFF
--- a/src/Layouts/Layout.php
+++ b/src/Layouts/Layout.php
@@ -6,8 +6,9 @@ use JsonSerializable;
 use Whitecube\NovaFlexibleContent\Http\ScopedRequest;
 use Whitecube\NovaFlexibleContent\Concerns\HasFlexible;
 use Illuminate\Database\Eloquent\Concerns\HasAttributes;
+use Illuminate\Contracts\Support\Arrayable;
 
-class Layout implements LayoutInterface, JsonSerializable
+class Layout implements LayoutInterface, JsonSerializable, Arrayable
 {
     use HasAttributes;
     use HasFlexible;
@@ -308,5 +309,15 @@ class Layout implements LayoutInterface, JsonSerializable
         }
 
         return substr(bin2hex($bytes), 0, 16);
+    }
+    
+    /**
+     * Convert the model instance to an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array_merge($this->attributesToArray(), $this->relationsToArray());
     }
 }

--- a/src/Layouts/Layout.php
+++ b/src/Layouts/Layout.php
@@ -188,15 +188,15 @@ class Layout implements LayoutInterface, JsonSerializable, Arrayable
             'layout' => $this->name,
 
             // The (old) temporary key is preferred to the new one during
-            // field resolving because we need to keep track of the current 
-            // attributes during the next fill request that will override 
+            // field resolving because we need to keep track of the current
+            // attributes during the next fill request that will override
             // the key with a new, stronger & definitive one.
             'key' => $this->_key ?? $this->key,
 
             // The layout's fields now temporarily contain the resolved
             // values from the current group's attributes. If multiple
             // groups use the same layout, the current values will be lost
-            // since each group uses the same fields by reference. That's 
+            // since each group uses the same fields by reference. That's
             // why we need to serialize the field's current state.
             'attributes' => $this->fields->jsonSerialize()
         ];
@@ -312,7 +312,7 @@ class Layout implements LayoutInterface, JsonSerializable, Arrayable
 
         return substr(bin2hex($bytes), 0, 16);
     }
-    
+
     /**
      * Convert the model instance to an array.
      *
@@ -320,6 +320,7 @@ class Layout implements LayoutInterface, JsonSerializable, Arrayable
      */
     public function toArray()
     {
-        return array_merge($this->attributesToArray(), $this->relationsToArray());
+        return $this->attributesToArray();
     }
+
 }

--- a/src/Layouts/Layout.php
+++ b/src/Layouts/Layout.php
@@ -6,11 +6,13 @@ use JsonSerializable;
 use Whitecube\NovaFlexibleContent\Http\ScopedRequest;
 use Whitecube\NovaFlexibleContent\Concerns\HasFlexible;
 use Illuminate\Database\Eloquent\Concerns\HasAttributes;
+use Illuminate\Database\Eloquent\Concerns\HidesAttributes;
 use Illuminate\Contracts\Support\Arrayable;
 
 class Layout implements LayoutInterface, JsonSerializable, Arrayable
 {
     use HasAttributes;
+    use HidesAttributes;
     use HasFlexible;
 
     /**


### PR DESCRIPTION
In order to be able to pass all attributes as an array to include sub view, example:

```
@include('flexible-content.'. $content->name(), $content)
```